### PR TITLE
fix: Harden GitHub Actions workflows and update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,35 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  # Check for updates to nuget packages
+  - package-ecosystem: "nuget"
+    directory: "/"
     schedule:
-      interval: "monthly"
-      time: "09:00"
-      timezone: "Europe/Oslo"
+      interval: 'cron'
+      cronjob: '0 8 * * MON#1'
+      timezone: 'Europe/Oslo'
+    labels:
+      - "dependencies"
+      - "nuget"
     commit-message:
-      prefix: "build:"
+      prefix: "fix:"
     groups:
-      all:
+      # Group all non-major updates together
+      minor-patch-updates:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  # Check for updates to GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-        interval: "monthly"
-        time: "09:00"
-        timezone: "Europe/Oslo"
+      interval: 'cron'
+      cronjob: '0 8 * * MON#1'
+      timezone: 'Europe/Oslo'
+    labels:
+      - "dependencies"
+      - "github-actions"
     commit-message:
       prefix: "ci:"
-    groups:
-      all:
-        patterns:
-          - "*"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,9 +5,13 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# action uses an app-token
+# the built-in token doesn't need any permissions
+permissions: {}
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to build workflow
- Restrict release workflow permissions to `{}` (uses app token, not GITHUB_TOKEN)
- Add concurrency group to release workflow
- Update dependabot schedule to first Monday of each month (cron)
- Change nuget commit prefix to `"fix:"`, add labels, separate minor/patch group

## Risk Assessment
- **Low risk** — no functional changes, only security hardening and CI configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)