### PR TITLE
fix: Bump the minor-patch-updates group with 2 updates

### DIFF
--- a/src/Intility.Authorization.Azure.GuestPolicies/Intility.Authorization.Azure.GuestPolicies.csproj
+++ b/src/Intility.Authorization.Azure.GuestPolicies/Intility.Authorization.Azure.GuestPolicies.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">

--- a/tests/Intility.Authorization.Azure.GuestPolicies.Tests/Intility.Authorization.Azure.GuestPolicies.Tests.csproj
+++ b/tests/Intility.Authorization.Azure.GuestPolicies.Tests/Intility.Authorization.Azure.GuestPolicies.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Summary
- Bump `Microsoft.AspNetCore.Authorization` (net9.0) from 9.0.13 to 9.0.14
- Bump `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.4.0

Replaces #45, which was closed because it was created before the dependabot ignore rule for major version bumps on `Microsoft.AspNetCore.Authorization` and incorrectly bumped the net8.0 reference.

## Test plan
- [x] `dotnet build` passes for all TFMs
- [x] `dotnet test` passes (net9.0 and net10.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)