### PR TITLE
fix: restore TFM-appropriate Microsoft.AspNetCore.Authorization versions

### DIFF
--- a/src/Intility.Authorization.Azure.GuestPolicies/Intility.Authorization.Azure.GuestPolicies.csproj
+++ b/src/Intility.Authorization.Azure.GuestPolicies/Intility.Authorization.Azure.GuestPolicies.csproj
@@ -23,11 +23,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.24" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="9.0.14" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">


### PR DESCRIPTION
## Summary

- Reverts the package-version changes from #49, which bumped `Microsoft.AspNetCore.Authorization` to `9.0.15` for **both** the `net8.0` and `net9.0` `<ItemGroup>` blocks.
- The `net8.0` change is the breaking one — net8.0 consumers must stay on the 8.x major. This PR restores `net8.0` to `8.0.24` and `net9.0` to `9.0.14` (the pre-#49 known-good state).
- No release was cut between #49 merging and this revert, so no published NuGet package is affected.

## Why this slipped past Dependabot

The `dependabot.yml` ignore rule on `version-update:semver-major` for `Microsoft.AspNetCore.Authorization` did not fire because Dependabot evaluates the package as a single entity. From its perspective, the dominant transition was `9.0.14 → 9.0.15` (a patch), so the grouped update was allowed — and it then applied `9.0.15` to every TFM-conditional `<ItemGroup>` reference, including the `net8.0` one.

A follow-up PR will add explicit Copilot review on Dependabot PRs plus repo instructions describing this exact failure mode.

## Test plan

- [x] `dotnet build` succeeds for `net8.0`, `net9.0`, and `net10.0` with 0 warnings.
- [ ] CI green on this PR.
- [ ] After merge, confirm next release-please PR opens at `2.2.4` (since this is `fix:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)