### PR TITLE
chore: auto-request Copilot review on Dependabot PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,36 @@
+# Repository instructions for GitHub Copilot
+
+## Project
+
+Multi-target NuGet library: `Intility.Authorization.Azure.GuestPolicies`. Targets `net8.0`, `net9.0`, and `net10.0`. Each TFM pins ASP.NET Core packages to its own major version.
+
+## Critical review rule for dependency updates
+
+**Do not allow `Microsoft.AspNetCore.Authorization` (or any package referenced under a TFM-conditional `<ItemGroup>`) to bump across major versions for a TFM that does not match.**
+
+The `csproj` uses `<ItemGroup Condition=" '$(TargetFramework)' == 'netX.0' ">` blocks. Each block must reference the package version whose major matches that TFM:
+
+| TFM | Allowed major version |
+|-----|----------------------|
+| `net8.0` | `8.x` only |
+| `net9.0` | `9.x` only |
+| `net10.0` | `10.x` only |
+
+**This is a hard backward-compatibility constraint.** A `net8.0` consumer must not be forced to load 9.x or 10.x of `Microsoft.AspNetCore.Authorization`.
+
+Dependabot cannot reason about TFM-conditional `PackageReference` items and will sometimes propose a single version for every TFM. Past incident: PR #49 bumped the `net8.0` line from `8.0.24` to `9.0.15`, breaking compat. It was reverted. **Block any PR that repeats this pattern.**
+
+## Review checklist for dependency PRs
+
+When reviewing a Dependabot or manual dependency PR, flag the PR as needing changes if any of these are true:
+
+1. A TFM-conditional `PackageReference` has its major version changed to one that does not match the TFM.
+2. All TFM-conditional `<ItemGroup>` blocks for the same package end up with the same version (this is almost always wrong for this repo).
+3. A new `PackageReference` is added outside a TFM-conditional `<ItemGroup>` for a package that already has TFM-conditional entries.
+4. The build matrix in `.github/workflows/build_and_test.yaml` is changed without a corresponding change to `<TargetFrameworks>` in the csproj (or vice versa).
+
+## Other conventions
+
+- Conventional Commits are required (release-please consumes them). `fix:` triggers patch, `feat:` triggers minor. Breaking changes use `!:` or `BREAKING CHANGE:` footer.
+- GitHub Actions must be pinned to a full commit SHA, not a tag. Flag any `uses: owner/action@vX` (mutable ref) in workflow changes.
+- Keep `permissions:` blocks minimal in workflows.

--- a/.github/workflows/dependabot-copilot-review.yaml
+++ b/.github/workflows/dependabot-copilot-review.yaml
@@ -1,0 +1,20 @@
+name: Request Copilot review on Dependabot PRs
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-copilot-review:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr edit "$PR_NUMBER" --repo "$REPO" --add-reviewer Copilot


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/dependabot-copilot-review.yaml` requests a Copilot review on every PR opened (or updated) by `dependabot[bot]`.
- New `.github/copilot-instructions.md` gives Copilot repo-wide context, with an explicit rule that calls out the TFM-conditional `PackageReference` cross-major bump pattern that caused #49 — so Copilot's review on future Dependabot PRs flags the exact failure mode we just hit.

## How it works

The workflow uses `pull_request_target` so it has the right token scope on PRs from forks/bots, runs only when the PR author is `dependabot[bot]`, and uses `gh pr edit --add-reviewer Copilot` (gh ≥ v2.88.0) to attach Copilot.

`copilot-instructions.md` is repo-wide and is read by Copilot from the **base branch** of any PR, which is what we want — Dependabot PRs target `main`, so they get reviewed against the rule set on `main`.

## Caveats reviewers should know

1. **Org licensing.** Copilot code review will only respond on bot-authored PRs if the org has enabled the pay-as-you-go option for non-licensed PR authors. If it is not enabled, the workflow will still run successfully but Copilot will silently not produce a review. Worth verifying in org settings.
2. **First-commit timing.** Copilot's automatic review historically does not always trigger on PR open — only on subsequent pushes. Explicitly requesting via `--add-reviewer` (this workflow) is the most reliable trigger.
3. **Custom-instructions limit.** Copilot reads only the first 4 000 characters of `copilot-instructions.md`. The current file is well under that.

## Test plan

- [ ] Merge → wait for next Dependabot PR (cron is last Monday of each month) **or** trigger manually by closing/reopening an existing Dependabot PR.
- [ ] Confirm the workflow runs with status success.
- [ ] Confirm Copilot is added as a reviewer on that PR.
- [ ] Confirm Copilot's review actually appears (this is the licensing caveat above).
- [ ] If Copilot does post a review, sanity-check that it surfaces the TFM rule when given a PR that violates it (can be tested locally by hand-crafting a PR that bumps `Microsoft.AspNetCore.Authorization` across a major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)